### PR TITLE
Add a workflow to deploy the slides to ICCS GitHub pages site.

### DIFF
--- a/.github/workflows/deploy_slides.yml
+++ b/.github/workflows/deploy_slides.yml
@@ -1,0 +1,54 @@
+# workflow to build and deploy slides to github pages
+
+name: BuildPages
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Workflow run - one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build" that builds pages site and slides
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+      
+      - name: Install python dependencies
+        run: pip install ./
+
+      - name: Render Quarto Project
+        run: |
+          cd presentation
+          quarto render Scientific_Vis.qmd
+          cd ../
+
+      - name: Test pages build
+        if: github.ref != 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: pages-test # The branch the action should deploy to.
+          folder: presentation      # The folder the action should deploy.
+          dry-run: true    # Don't actually push to pages, just test if we can
+
+      - name: Deploy pages for master
+        if: github.ref == 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: presentation   # The folder the action should deploy.

--- a/.github/workflows/deploy_slides.yml
+++ b/.github/workflows/deploy_slides.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
       
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Install python dependencies
         run: pip install ./
 

--- a/presentation/Scientific_Vis.qmd
+++ b/presentation/Scientific_Vis.qmd
@@ -1,4 +1,5 @@
 ---
+output-file: index
 title: Scientific visualisation with Python
 authors:
   - name: James Emberton


### PR DESCRIPTION
As per the description.
This will deploy the slides on the main branch as html to the ICCS github.io site to be viewed and shared.

This requires #13 to be merged to allow dependency installation

This also requires me to be give access to the settings to set up GitHub pages backend.
Please could you do this @j-emberton ?
I think we will also need to make the repo public to do this, but I see no reason not to do that.